### PR TITLE
Add --no-wait flag to allow immediate execution

### DIFF
--- a/debugpy_run.py
+++ b/debugpy_run.py
@@ -51,6 +51,8 @@ def main():
             help=f'only run the globally installed {PROG}')
     opt.add_argument('-r', '--run-on-error', action='store_true',
             help='re-run program/module even on error')
+    opt.add_argument('--no-wait', action='store_true',
+            help='do not wait for the client to connect, start execution immediately')
     grp = opt.add_mutually_exclusive_group()
     grp.add_argument('--log-to', metavar='PATH',
             help='log to given path')
@@ -120,6 +122,8 @@ def main():
     else:
         ctype = 'listen'
         wait = ' --wait-for-client'
+    if args.no_wait:
+        wait = ''
 
     if args.log_to:
         logto = f' --log-to {args.log_to}'


### PR DESCRIPTION
Motivation: automatically launching a long-running computation (e.g., an ML training job on a cluster), and then being able to connect and debug _that process_ in its current state. The time to arrive to the buggy state might be hours/days, and the current workaround – run a new job, immediately connect, keep the SSH connection open, and wait for the bug to emerge again – is not ideal.