### PR TITLE
fix(debug_run): add missing space infront of --wait-for-client option

### DIFF
--- a/debugpy_run.py
+++ b/debugpy_run.py
@@ -121,7 +121,7 @@ def main():
         wait = ''
     else:
         ctype = 'listen'
-        wait = '' if args.no_wait else '--wait-for-client'
+        wait = '' if args.no_wait else ' --wait-for-client'
 
     if args.log_to:
         logto = f' --log-to {args.log_to}'


### PR DESCRIPTION
It seems like [this commit](https://github.com/bulletmark/debugpy-run/commit/946940439e6a7a596c23d2316b20ed318a8528bc#diff-ae25415c92c777d31cd8bfa5e396007ffa0165d975c56b8e22cdb3e061adb65fR124) removed the extra space.

Without the space, `debugpy` would receive `--listen 5678--wait-for-client`
causing `Error: invalid --listen <address>: invalid port number` to be
thrown.